### PR TITLE
Add login page

### DIFF
--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SignInPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch("/api/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        router.push("/");
+      } else {
+        const data = await res.json().catch(() => null);
+        setError(data?.message ?? "로그인에 실패했습니다");
+      }
+    } catch {
+      setError("네트워크 오류가 발생했습니다");
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 rounded border p-6 shadow"
+      >
+        <h1 className="text-2xl font-bold">Sign In</h1>
+        <div>
+          <label className="mb-2 block text-sm font-medium" htmlFor="email">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="mb-2 block text-sm font-medium" htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          className="w-full rounded bg-blue-600 py-2 font-semibold text-white hover:bg-blue-700"
+        >
+          Sign In
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/sign-in` page with email and password form
- POST credentials to `/api/sign-in`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f94c463dc83238c40d33fb705f3a1