### PR TITLE
Add reusable sidebar layout component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,14 @@
+import SidebarLayout from "@/components/layouts/SidebarLayout";
+
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <h1 className="text-4xl font-bold">홈페이지 Develop 2</h1>
-    </div>
+    <SidebarLayout
+      sidebar={<nav className="p-2">Sidebar</nav>}
+      header={<h1 className="text-xl font-semibold">Header</h1>}
+    >
+      <div className="flex h-full items-center justify-center">
+        <p className="text-4xl font-bold">홈페이지 Develop 2</p>
+      </div>
+    </SidebarLayout>
   );
 }

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from "react";
+"use client";
+import { ReactNode, useState } from "react";
 
 interface SidebarLayoutProps {
   sidebar: ReactNode;
@@ -11,11 +12,22 @@ export default function SidebarLayout({
   header,
   children,
 }: SidebarLayoutProps) {
+  const [open, setOpen] = useState(true);
+
   return (
     <div className="flex min-h-screen">
-      <aside className="w-64 border-r bg-background p-4">{sidebar}</aside>
+      {open && <aside className="w-64 border-r bg-background p-4">{sidebar}</aside>}
       <div className="flex flex-1 flex-col">
-        {header && <header className="border-b p-4">{header}</header>}
+        <header className="flex items-center gap-2 border-b p-4">
+          {header}
+          <button
+            type="button"
+            className="rounded border px-2 py-1"
+            onClick={() => setOpen((prev) => !prev)}
+          >
+            {open ? "닫기" : "열기"}
+          </button>
+        </header>
         <main className="flex-1 p-4">{children}</main>
       </div>
     </div>

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+
+interface SidebarLayoutProps {
+  sidebar: ReactNode;
+  header?: ReactNode;
+  children: ReactNode;
+}
+
+export default function SidebarLayout({
+  sidebar,
+  header,
+  children,
+}: SidebarLayoutProps) {
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-64 border-r bg-background p-4">{sidebar}</aside>
+      <div className="flex flex-1 flex-col">
+        {header && <header className="border-b p-4">{header}</header>}
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SidebarLayout` component for sidebar/header structure
- use the new layout in the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f9f6665288323868de6c759a11366