### PR TITLE
Add placeholder weather and graph widgets

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,27 @@
 import SidebarLayout from "@/components/layouts/SidebarLayout";
+import AdCarousel from "@/components/AdCarousel";
+import Header from "@/components/Header";
+
+const images = [
+  "https://via.placeholder.com/800x200?text=Ad+1",
+  "https://via.placeholder.com/800x200?text=Ad+2",
+  "https://via.placeholder.com/800x200?text=Ad+3",
+];
 
 export default function Home() {
   return (
     <SidebarLayout
       sidebar={<nav className="p-2">Sidebar</nav>}
-      header={<h1 className="text-xl font-semibold">Header</h1>}
+      header={<Header />}
     >
-      <div className="flex h-full items-center justify-center">
-        <p className="text-4xl font-bold">홈페이지 Develop 2</p>
+      <AdCarousel images={images} />
+      <div className="mt-4 grid grid-cols-12 gap-4">
+        <div className="col-span-4">
+          <div className="rounded border p-4 text-center">날씨 예시</div>
+        </div>
+        <div className="col-span-8">
+          <div className="rounded border p-4 text-center">그래프 예시</div>
+        </div>
       </div>
     </SidebarLayout>
   );

--- a/src/components/AdCarousel.tsx
+++ b/src/components/AdCarousel.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useState, useEffect } from "react";
+
+export default function AdCarousel({ images }: { images: string[] }) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % images.length);
+    }, 3000);
+    return () => clearInterval(id);
+  }, [images.length]);
+
+  return (
+    <div className="overflow-hidden rounded border">
+      <div
+        className="flex transition-transform duration-500"
+        style={{ transform: `translateX(-${index * 100}%)` }}
+      >
+        {images.map((src, i) => (
+          <img
+            key={i}
+            src={src}
+            alt={`Ad ${i}`}
+            className="h-48 w-full flex-shrink-0 object-cover"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <div className="flex w-full items-center justify-between">
+      <Link href="/sign-in" className="text-sm font-medium underline">
+        로그인
+      </Link>
+      <h1 className="text-xl font-semibold">Header</h1>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,3 @@
-import Link from "next/link";
-
 export default function Header() {
-  return (
-    <div className="flex w-full items-center justify-between">
-      <Link href="/sign-in" className="text-sm font-medium underline">
-        로그인
-      </Link>
-      <h1 className="text-xl font-semibold">Header</h1>
-    </div>
-  );
+  return <h1 className="text-xl font-semibold">Header</h1>;
 }

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { ReactNode, useState } from "react";
+import Link from "next/link";
 
 interface SidebarLayoutProps {
   sidebar: ReactNode;
@@ -16,17 +17,24 @@ export default function SidebarLayout({
 
   return (
     <div className="flex min-h-screen">
-      {open && <aside className="w-64 border-r bg-background p-4">{sidebar}</aside>}
+      {open && (
+        <aside className="w-64 border-r bg-background p-4">{sidebar}</aside>
+      )}
       <div className="flex flex-1 flex-col">
-        <header className="flex items-center gap-2 border-b p-4">
-          {header}
-          <button
-            type="button"
-            className="rounded border px-2 py-1"
-            onClick={() => setOpen((prev) => !prev)}
-          >
-            {open ? "닫기" : "열기"}
-          </button>
+        <header className="flex items-center justify-between border-b p-4">
+          <div className="flex items-center gap-2">
+            {header}
+            <button
+              type="button"
+              className="rounded border px-2 py-1"
+              onClick={() => setOpen((prev) => !prev)}
+            >
+              {open ? "닫기" : "열기"}
+            </button>
+          </div>
+          <Link href="/sign-in" className="text-sm font-medium underline">
+            로그인
+          </Link>
         </header>
         <main className="flex-1 p-4">{children}</main>
       </div>


### PR DESCRIPTION
## Summary
- add a header component with a sign-in link
- add a simple auto-advancing ad banner carousel
- show the carousel, weather and graph sections on the home page

## Testing
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_683fa566bd548323b77d27111321c44e