### PR TITLE
Improve sidebar transitions and responsive behavior

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --background: #ffffff;
+  --foreground: #000000;
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+}

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -26,14 +26,17 @@ export default function SidebarLayout({
       <aside
         className={`fixed inset-y-0 left-0 z-20 w-64 border-r bg-background p-4 transition-transform duration-300 ${open ? "translate-x-0" : "-translate-x-full"} md:static md:translate-x-0`}
       >
-        <button
-          type="button"
-          className="mb-4 rounded border px-2 py-1 md:hidden"
-          onClick={() => setOpen(false)}
-        >
-          닫기
-        </button>
-        {sidebar}
+        <div className="mb-4 flex items-center justify-between md:hidden">
+          {sidebar}
+          <button
+            type="button"
+            className="rounded border px-2 py-1"
+            onClick={() => setOpen(false)}
+          >
+            닫기
+          </button>
+        </div>
+        <div className="hidden md:block">{sidebar}</div>
       </aside>
       <div className="flex flex-1 flex-col">
         <header className="flex items-center justify-between border-b p-4">

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -17,9 +17,22 @@ export default function SidebarLayout({
 
   return (
     <div className="flex min-h-screen overflow-x-hidden">
+      {open && (
+        <div
+          className="fixed inset-0 z-10 bg-black/50 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
       <aside
         className={`fixed inset-y-0 left-0 z-20 w-64 border-r bg-background p-4 transition-transform duration-300 ${open ? "translate-x-0" : "-translate-x-full"} md:static md:translate-x-0`}
       >
+        <button
+          type="button"
+          className="mb-4 rounded border px-2 py-1 md:hidden"
+          onClick={() => setOpen(false)}
+        >
+          닫기
+        </button>
         {sidebar}
       </aside>
       <div className="flex flex-1 flex-col">

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -13,20 +13,22 @@ export default function SidebarLayout({
   header,
   children,
 }: SidebarLayoutProps) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="flex min-h-screen">
-      {open && (
-        <aside className="w-64 border-r bg-background p-4">{sidebar}</aside>
-      )}
+    <div className="flex min-h-screen overflow-x-hidden">
+      <aside
+        className={`fixed inset-y-0 left-0 z-20 w-64 border-r bg-background p-4 transition-transform duration-300 ${open ? "translate-x-0" : "-translate-x-full"} md:static md:translate-x-0`}
+      >
+        {sidebar}
+      </aside>
       <div className="flex flex-1 flex-col">
         <header className="flex items-center justify-between border-b p-4">
           <div className="flex items-center gap-2">
             {header}
             <button
               type="button"
-              className="rounded border px-2 py-1"
+              className="rounded border px-2 py-1 md:hidden"
               onClick={() => setOpen((prev) => !prev)}
             >
               {open ? "닫기" : "열기"}


### PR DESCRIPTION
## Summary
- smooth sidebar animation
- hide sidebar on small screens until header button is pressed

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683fab20c1c8832380929b0fa86bc193