### PR TITLE
Add sample graph form

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
           <div className="rounded border p-4 text-center">날씨 예시</div>
         </div>
         <div className="col-span-8 space-y-4">
-          <GraphExample />
+          <div className="rounded border p-4 text-center">그래프 예시</div>
           <GraphExample />
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import SidebarLayout from "@/components/layouts/SidebarLayout";
 import AdCarousel from "@/components/AdCarousel";
 import Header from "@/components/Header";
+import GraphExample from "@/components/GraphExample";
 
 const images = [
   "https://via.placeholder.com/800x200?text=Ad+1",
@@ -19,8 +20,9 @@ export default function Home() {
         <div className="col-span-4">
           <div className="rounded border p-4 text-center">날씨 예시</div>
         </div>
-        <div className="col-span-8">
-          <div className="rounded border p-4 text-center">그래프 예시</div>
+        <div className="col-span-8 space-y-4">
+          <GraphExample />
+          <GraphExample />
         </div>
       </div>
     </SidebarLayout>

--- a/src/components/GraphExample.tsx
+++ b/src/components/GraphExample.tsx
@@ -1,0 +1,21 @@
+export default function GraphExample() {
+  return (
+    <div className="rounded border p-4">
+      <h2 className="text-center font-semibold">그래프 예시</h2>
+      <div className="mt-4 grid grid-cols-12 gap-2">
+        <select className="col-span-4 rounded border p-2">
+          <option>1차카테고리</option>
+        </select>
+        <select className="col-span-4 rounded border p-2">
+          <option>2차카테고리</option>
+        </select>
+        <input
+          type="text"
+          placeholder="텍스트 입력"
+          className="col-span-4 rounded border p-2"
+        />
+      </div>
+      <div className="mt-4 h-40 rounded bg-gray-100" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GraphExample` component for graph sample with category and text inputs
- show two graph examples in Home page

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fbb3d12908323b26c0a71bb18ca69